### PR TITLE
fix: ensure approov token is never overwritten

### DIFF
--- a/src/react-native-approov/support-files/ApproovFetchSupport.js
+++ b/src/react-native-approov/support-files/ApproovFetchSupport.js
@@ -1,15 +1,15 @@
 /**
  * Copyright 2020 CriticalBlue Ltd.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -48,17 +48,17 @@ const approovFetch = async (url, args) => {
       }
     }
 
-    // authenticate the app with Approov servers and fetch an Approov token 
+    // authenticate the app with Approov servers and fetch an Approov token
     const result = await Approov.fetchApproovToken(url);
     console.log("Fetched Approov token: " + result.loggableToken);
 
     // delegate to the existing fetch API method, adding the Approov token as a new request header
     const fetchPromise = oldFetch(url, {
+      ...args,
       headers: {
         'Approov-Token' : '' + result.token,
-        ...args.headers,
+        ...(args.headers || {}),
       },
-      ...args,
     });
 
     // check for SSL pinning errors


### PR DESCRIPTION
POC to demonstrate the issues mentioned with the way that arguments are spread onto fetch. The intention is not for this to be merged, but for **_illustration_** only.

**Problem Summary**
In short, there are two issues:
- if custom headers are passed in the args, then these would blow away the approov token setup in this file, due to the spread of args _**after**_ setting up the approov token headers.
- if custom headers are not passed, i.e. `args.headers` is undefined, the attempt to spread `args.headers` would throw.

In summary, if you pass your own headers, it will cause the token to not be passed in headers, if you don't you will get an exception, so not sure how this could have ever worked.

What this meant for us is that the token was never being passed to our backend and therefore all requests were rejected. 

**Fix Summary**
- I have moved the argument spread setup _**before**_ the header setup, meaning it will always take precedent and any passed headers will be handled in the spread of `args.headers`
- In the case that there are no custom headers passed, `args.headers` defaults to an empty object to mitigate the exception
- The spread of `args.headers` is _**after**_ the approov token header setup, allowing it to be manually overridden if necessary (probably never the case, but more flexible)

**What could be added**
Adding unit tests for at least these support files would be ideal, if I had time and testing was already setup in the repo, then I would have used nock js to test these scenarios.